### PR TITLE
Add support for Pale Moon

### DIFF
--- a/extensions/seamonkey/install.rdf
+++ b/extensions/seamonkey/install.rdf
@@ -36,6 +36,15 @@
      </Description>
     </em:targetApplication>
 
+    <!-- Pale Moon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>28.0.0</em:minVersion>
+        <em:maxVersion>28.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
     <!-- Android -->
     <em:targetApplication>
       <Description>


### PR DESCRIPTION
This PDF.js extension works very well on Pale Moon 28 and is actually [recommended][1] by the only "PDF Viewer" extension on the Pale Moon Add-ons Site. This PR adds Pale Moon's GUID as a `targetApplication`, which shows it as a Pale Moon extension in the Add-ons Manager and [will eventually be required for any Pale Moon compatibility][2].

[1]: https://addons.palemoon.org/addon/moon-pdf-viewer/
[2]: https://forum.palemoon.org/viewtopic.php?f=46&t=23697